### PR TITLE
Refactor: AIAlgo configures other algorithms and simplifies config

### DIFF
--- a/config/algo.json
+++ b/config/algo.json
@@ -1,24 +1,4 @@
 {
-  "GuppyMMA": {
-    "short_term": [
-      3,
-      5,
-      8,
-      10,
-      12,
-      15
-    ],
-    "long_term": [
-      30,
-      35,
-      40,
-      45,
-      50,
-      60
-    ],
-    "buy": 6,
-    "sell": 6
-  },
   "maxLost": {
     "percentage": 3,
     "percentage_update": 0.25,
@@ -26,13 +6,6 @@
   },
   "takeProfit": {
     "percentage": 5.0
-  },
-  "Bollinger": {
-    "frequency": 289
-  },
-  "MovingAverageCrossover": {
-    "short_window": 20,
-    "long_window": 50
   },
   "AIAlgo": {
     "enabled": true,

--- a/crypto_trading/algo/ai_algo.py
+++ b/crypto_trading/algo/ai_algo.py
@@ -25,6 +25,25 @@ class AIAlgo(AlgoIf):
 
     def __init__(self, config_dict):
         super().__init__(config_dict)
+        self.algo_configs = {}
+
+        # Populate default algo_configs
+        # These values are typically loaded from a config file (e.g., algo.json)
+        # but here we are setting them as coded defaults for AIAlgo's internal reference
+        self.algo_configs['GuppyMMA'] = {
+            "short_term": [3, 5, 8, 10, 12, 15],
+            "long_term": [30, 35, 40, 45, 50, 60],
+            "buy": 6,
+            "sell": 6
+        }
+        self.algo_configs['Bollinger'] = {
+            "frequency": 289
+        }
+        self.algo_configs['MovingAverageCrossover'] = {
+            "short_window": 20,
+            "long_window": 50
+        }
+
         self.model = None
         self.expected_input_size = self.NUM_PRICE_FEATURES + len(self.TARGET_INDICATOR_KEYS)
 
@@ -139,3 +158,6 @@ class AIAlgo(AlgoIf):
         except Exception as e:
             logging.error(f"Error during AIAlgo process: {e}")
             return 0 # Neutral signal on error
+
+    def get_target_algo_configs(self):
+        return self.algo_configs

--- a/crypto_trading/algo/algoMain.py
+++ b/crypto_trading/algo/algoMain.py
@@ -19,12 +19,35 @@ class AlgoMain:
 
         self.__dict__ = json.load(open(config_dict, mode='r'))
         self.algo_ifs = []
-        self.algo_ifs.append(average.GuppyMMA(config_dict))
-        self.algo_ifs.append(bollinger.Bollinger(config_dict))
-        self.algo_ifs.append(moving_average_crossover.MovingAverageCrossover(config_dict))
+        ai_algo_instance = None
+        ai_target_configs = {}
 
         if self.__dict__.get("AIAlgo", {}).get("enabled", False):
-            self.algo_ifs.append(AIAlgo(self.__dict__))
+            # Pass the main config dict to AIAlgo constructor
+            ai_algo_instance = AIAlgo(self.__dict__)
+            ai_target_configs = ai_algo_instance.get_target_algo_configs()
+            self.algo_ifs.append(ai_algo_instance)
+
+        # Instantiate GuppyMMA
+        guppy_config = self.__dict__.copy()
+        if ai_algo_instance and 'GuppyMMA' in ai_target_configs:
+            # Update the 'GuppyMMA' key in our copy of the main config
+            guppy_config['GuppyMMA'] = ai_target_configs['GuppyMMA']
+        self.algo_ifs.append(average.GuppyMMA(guppy_config))
+
+        # Instantiate Bollinger
+        bollinger_config = self.__dict__.copy()
+        if ai_algo_instance and 'Bollinger' in ai_target_configs:
+            # Update the 'Bollinger' key in our copy of the main config
+            bollinger_config['Bollinger'] = ai_target_configs['Bollinger']
+        self.algo_ifs.append(bollinger.Bollinger(bollinger_config))
+
+        # Instantiate MovingAverageCrossover
+        mac_config = self.__dict__.copy()
+        if ai_algo_instance and 'MovingAverageCrossover' in ai_target_configs:
+            # Update the 'MovingAverageCrossover' key in our copy of the main config
+            mac_config['MovingAverageCrossover'] = ai_target_configs['MovingAverageCrossover']
+        self.algo_ifs.append(moving_average_crossover.MovingAverageCrossover(mac_config))
 
         self.max_frequencies = 0
         if self.algo_ifs:

--- a/tests/algo/algoContainer_tests.py
+++ b/tests/algo/algoContainer_tests.py
@@ -1,1 +1,105 @@
 #!/usr/bin/env python
+
+import unittest
+import json
+import os
+import logging # Added for potential debugging, can be removed if not used
+from crypto_trading.algo.algoMain import AlgoMain
+from crypto_trading.algo.ai_algo import AIAlgo
+# Import base classes to check attributes, assuming they store config directly
+from crypto_trading.algo.average import GuppyMMA
+from crypto_trading.algo.bollinger import Bollinger
+from crypto_trading.algo.moving_average_crossover import MovingAverageCrossover
+
+
+class TestAlgoMain(unittest.TestCase):
+    CONFIG_FILE_PATH = "test_algo_config.json"
+
+    def setUp(self):
+        # Clean up any old config file before a test
+        if os.path.exists(self.CONFIG_FILE_PATH):
+            os.remove(self.CONFIG_FILE_PATH)
+
+    def tearDown(self):
+        # Clean up config file after each test
+        if os.path.exists(self.CONFIG_FILE_PATH):
+            os.remove(self.CONFIG_FILE_PATH)
+
+    def write_config(self, data):
+        with open(self.CONFIG_FILE_PATH, 'w') as f:
+            json.dump(data, f)
+
+    def test_algo_main_with_ai_disabled(self):
+        config_data = {
+            "GuppyMMA": {"short_term": [1, 2, 3], "long_term": [10, 20], "buy": 1, "sell": 1},
+            "Bollinger": {"frequency": 100},
+            "MovingAverageCrossover": {"short_window": 5, "long_window": 10},
+            "AIAlgo": {"enabled": False, "model_path": "dummy/path.pth"} # model_path needed by AIAlgo init
+        }
+        self.write_config(config_data)
+
+        algo_main = AlgoMain(self.CONFIG_FILE_PATH)
+
+        self.assertFalse(any(isinstance(algo, AIAlgo) for algo in algo_main.algo_ifs), "AIAlgo instance found when it should be disabled.")
+
+        guppy = next((a for a in algo_main.algo_ifs if isinstance(a, GuppyMMA)), None)
+        bollinger = next((a for a in algo_main.algo_ifs if isinstance(a, Bollinger)), None)
+        mac = next((a for a in algo_main.algo_ifs if isinstance(a, MovingAverageCrossover)), None)
+
+        self.assertIsNotNone(guppy, "GuppyMMA instance not found.")
+        self.assertIsNotNone(bollinger, "Bollinger instance not found.")
+        self.assertIsNotNone(mac, "MovingAverageCrossover instance not found.")
+
+        # These assertions rely on GuppyMMA, Bollinger, and MovingAverageCrossover classes
+        # storing their parameters directly as attributes with these names.
+        # This is based on the assumption that their __init__ methods would parse the 'GuppyMMA' (etc.)
+        # section of the config_dict passed to them and set attributes accordingly.
+        # For example, in GuppyMMA's __init__(self, config_dict):
+        #   guppy_conf = config_dict.get('GuppyMMA', {})
+        #   self.short_term = guppy_conf.get('short_term')
+        #   self.long_term = guppy_conf.get('long_term')
+        #   ... etc.
+        self.assertEqual(guppy.short_terms, [1, 2, 3])
+        self.assertEqual(bollinger.frequency, 100)
+        self.assertEqual(mac.short_window, 5)
+
+    def test_algo_main_with_ai_enabled_overrides_configs(self):
+        # Config with AI enabled, and some (potentially conflicting) values for other algos in the main config
+        # These conflicting values should be ignored by GuppyMMA, Bollinger, MAC if AIAlgo provides defaults.
+        config_data = {
+            "GuppyMMA": {"short_term": [99, 98], "long_term": [100, 200], "buy": 9, "sell": 9},
+            "Bollinger": {"frequency": 500},
+            "MovingAverageCrossover": {"short_window": 1, "long_window": 2},
+            "AIAlgo": {"enabled": True, "model_path": "dummy/ai_model.pth"} # dummy path is fine, AIAlgo will use PlaceholderNet
+        }
+        self.write_config(config_data)
+
+        algo_main = AlgoMain(self.CONFIG_FILE_PATH)
+
+        ai_instance = next((algo for algo in algo_main.algo_ifs if isinstance(algo, AIAlgo)), None)
+        self.assertIsNotNone(ai_instance, "AIAlgo instance not found when it should be enabled.")
+
+        # These are the default configs AIAlgo should provide
+        expected_configs_from_ai = ai_instance.get_target_algo_configs()
+
+        guppy = next((a for a in algo_main.algo_ifs if isinstance(a, GuppyMMA)), None)
+        bollinger = next((a for a in algo_main.algo_ifs if isinstance(a, Bollinger)), None)
+        mac = next((a for a in algo_main.algo_ifs if isinstance(a, MovingAverageCrossover)), None)
+
+        self.assertIsNotNone(guppy, "GuppyMMA instance not found.")
+        self.assertIsNotNone(bollinger, "Bollinger instance not found.")
+        self.assertIsNotNone(mac, "MovingAverageCrossover instance not found.")
+
+        # Check that the instances of GuppyMMA, Bollinger, MAC have parameters from AIAlgo's defaults
+        self.assertEqual(guppy.short_terms, expected_configs_from_ai['GuppyMMA']['short_term'])
+        self.assertEqual(guppy.long_terms, expected_configs_from_ai['GuppyMMA']['long_term'])
+        self.assertEqual(guppy.buy, expected_configs_from_ai['GuppyMMA']['buy'])
+        self.assertEqual(guppy.sell, expected_configs_from_ai['GuppyMMA']['sell'])
+
+        self.assertEqual(bollinger.frequency, expected_configs_from_ai['Bollinger']['frequency'])
+
+        self.assertEqual(mac.short_window, expected_configs_from_ai['MovingAverageCrossover']['short_window'])
+        self.assertEqual(mac.long_window, expected_configs_from_ai['MovingAverageCrossover']['long_window'])
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/algo/test_ai_algo.py
+++ b/tests/algo/test_ai_algo.py
@@ -98,5 +98,26 @@ class TestAIAlgo(unittest.TestCase):
         signal = algo_no_path.process(self.current_value, self.sufficient_values, self.currency, self.full_indicator_signals)
         self.assertIn(signal, [-1, 0, 1], "Signal should be -1, 0, or 1 even if model_path key is missing")
 
+    def test_get_target_algo_configs(self):
+        """
+        Tests the get_target_algo_configs method for correct structure and default values.
+        """
+        configs = self.ai_algo.get_target_algo_configs()
+        self.assertIsInstance(configs, dict)
+
+        expected_keys = ['GuppyMMA', 'Bollinger', 'MovingAverageCrossover']
+        for key in expected_keys:
+            self.assertIn(key, configs)
+            self.assertIsInstance(configs[key], dict)
+
+        # Assert specific default values
+        self.assertEqual(configs['GuppyMMA']['short_term'], [3, 5, 8, 10, 12, 15])
+        self.assertEqual(configs['GuppyMMA']['long_term'], [30, 35, 40, 45, 50, 60])
+        self.assertEqual(configs['GuppyMMA']['buy'], 6)
+        self.assertEqual(configs['GuppyMMA']['sell'], 6)
+        self.assertEqual(configs['Bollinger']['frequency'], 289)
+        self.assertEqual(configs['MovingAverageCrossover']['short_window'], 20)
+        self.assertEqual(configs['MovingAverageCrossover']['long_window'], 50)
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This change enables the AIAlgo module to dynamically configure other dependent algorithm modules (GuppyMMA, Bollinger, MovingAverageCrossover).

Key changes:
- AIAlgo now internally defines default configurations for its target indicator algorithms.
- AlgoMain has been refactored to prioritize configurations provided by AIAlgo over those in `config/algo.json` when AIAlgo is enabled.
- The `config/algo.json` file has been simplified by removing the explicit configurations for GuppyMMA, Bollinger, and MovingAverageCrossover, as these are now managed by AIAlgo.
- This reduces the complexity of the `algo.json` file for you when AIAlgo is active, thereby simplifying frontend configuration.
- Added unit tests to verify AIAlgo's configuration provision and AlgoMain's correct application of these configurations.