### PR TITLE
Refactor algo module to use SQLAlchemy

### DIFF
--- a/tests/algo/algoContainer_tests.py
+++ b/tests/algo/algoContainer_tests.py
@@ -6,6 +6,8 @@ import os
 import logging
 import torch # For AIAlgo process mock output
 from unittest.mock import patch, MagicMock, call # call for checking multiple calls to update_config
+from sqlalchemy.orm import Session # Added
+from crypto_trading.config import Config # Added
 from crypto_trading.algo.algoMain import AlgoMain
 from crypto_trading.algo.ai_algo import AIAlgo
 from crypto_trading.algo.average import GuppyMMA
@@ -39,7 +41,8 @@ class TestAlgoMain(unittest.TestCase):
             "AIAlgo": {"enabled": False, "model_path": "dummy/path.pth"}
         }
         self.write_config(config_data)
-        algo_main = AlgoMain(self.CONFIG_FILE_PATH)
+        config_obj = Config(algo_config_path=self.CONFIG_FILE_PATH)
+        algo_main = AlgoMain(config_obj)
         self.assertFalse(any(isinstance(algo, AIAlgo) for algo in algo_main.algo_ifs))
         # ... (rest of the assertions from original test are good)
 
@@ -51,7 +54,8 @@ class TestAlgoMain(unittest.TestCase):
             "AIAlgo": {"enabled": True, "model_path": "dummy/ai_model.pth"}
         }
         self.write_config(config_data)
-        algo_main = AlgoMain(self.CONFIG_FILE_PATH)
+        config_obj = Config(algo_config_path=self.CONFIG_FILE_PATH)
+        algo_main = AlgoMain(config_obj)
         ai_instance = next((algo for algo in algo_main.algo_ifs if isinstance(algo, AIAlgo)), None)
         self.assertIsNotNone(ai_instance)
         expected_configs_from_ai = ai_instance.get_target_algo_configs()
@@ -62,12 +66,14 @@ class TestAlgoMain(unittest.TestCase):
         self.assertEqual(bollinger.frequency, expected_configs_from_ai['Bollinger']['frequency'])
         self.assertEqual(mac.short_window, expected_configs_from_ai['MovingAverageCrossover']['short_window'])
 
+    @patch('crypto_trading.database.core_operations.save_price_tick') # Added
     @patch('crypto_trading.algo.model.pricing.get_last_values') # Mock fetching historical values
-    def test_algo_main_process_with_ai_and_updates(self, mock_get_last_values):
+    def test_algo_main_process_with_ai_and_updates(self, mock_get_last_values, mock_save_price_tick): # Added mock_save_price_tick
         """
         Test AlgoMain.process when AIAlgo is enabled and provides new configurations.
         """
         mock_get_last_values.return_value = [90.0, 95.0] # Dummy historical values
+        mock_session = MagicMock(spec=Session) # Added
 
         config_data = {
             "GuppyMMA": {}, # Keep these minimal, AI will provide initial and then update
@@ -76,7 +82,8 @@ class TestAlgoMain(unittest.TestCase):
             "AIAlgo": {"enabled": True, "model_path": "dummy/ai_model.pth"}
         }
         self.write_config(config_data)
-        algo_main = AlgoMain(self.CONFIG_FILE_PATH)
+        config_obj = Config(algo_config_path=self.CONFIG_FILE_PATH)
+        algo_main = AlgoMain(config_obj)
 
         # Find the instantiated algorithms
         ai_algo_instance = next(algo for algo in algo_main.algo_ifs if isinstance(algo, AIAlgo))
@@ -104,10 +111,16 @@ class TestAlgoMain(unittest.TestCase):
         mac_instance.update_config = MagicMock()
 
         # --- Call AlgoMain.process ---
-        total_signal = algo_main.process(self.current_value, self.currency)
+        total_signal = algo_main.process(mock_session, self.current_value, self.currency) # Updated call
 
         # --- Assertions ---
-        # 1. Assert AIAlgo.process was called correctly
+        # 0. Assert save_price_tick was called
+        mock_save_price_tick.assert_called_once_with(session=mock_session, currency_pair=self.currency, price=self.current_value) # Added
+
+        # 1. Assert get_last_values was called correctly
+        mock_get_last_values.assert_called_once_with(session=mock_session, currency_pair=self.currency, count=algo_main.max_frequencies) # Updated
+
+        # 2. Assert AIAlgo.process was called correctly
         # indicator_signals for AI: {'GuppyMMA': 1, 'Bollinger': -1, 'MovingAverageCrossover': 0}
         expected_indicator_signals = {'GuppyMMA': 1, 'Bollinger': -1, 'MovingAverageCrossover': 0}
         ai_algo_instance.process.assert_called_once_with(
@@ -123,13 +136,16 @@ class TestAlgoMain(unittest.TestCase):
         # Guppy (1) + Bollinger (-1) + MAC (0) + AI (1) = 1
         self.assertEqual(total_signal, 1)
 
+    @patch('crypto_trading.database.core_operations.save_price_tick') # Added
     @patch('crypto_trading.algo.model.pricing.get_last_values')
-    def test_algo_main_process_ai_empty_configs(self, mock_get_last_values):
+    def test_algo_main_process_ai_empty_configs(self, mock_get_last_values, mock_save_price_tick): # Added mock_save_price_tick
         """Test AlgoMain.process when AIAlgo returns an empty config map."""
         mock_get_last_values.return_value = []
+        mock_session = MagicMock(spec=Session) # Added
         config_data = {"AIAlgo": {"enabled": True, "model_path": "dummy/ai_model.pth"}, "GuppyMMA": {}, "Bollinger": {}, "MovingAverageCrossover": {}}
         self.write_config(config_data)
-        algo_main = AlgoMain(self.CONFIG_FILE_PATH)
+        config_obj = Config(algo_config_path=self.CONFIG_FILE_PATH)
+        algo_main = AlgoMain(config_obj)
 
         ai_algo_instance = next(algo for algo in algo_main.algo_ifs if isinstance(algo, AIAlgo))
         guppy_instance = next(algo for algo in algo_main.algo_ifs if isinstance(algo, GuppyMMA))
@@ -151,13 +167,15 @@ class TestAlgoMain(unittest.TestCase):
                 algo.update_config = MagicMock()
 
         with patch.object(logging, 'debug') as mock_log_debug:
-            algo_main.process(self.current_value, self.currency)
+            algo_main.process(mock_session, self.current_value, self.currency) # Updated call
             # Check if "AIAlgo did not produce new configurations this cycle." or
             # "AIAlgo ran but provided no new configurations to apply." was logged.
             # This requires checking all calls to mock_log_debug
             self.assertTrue(any("AIAlgo did not produce new configurations this cycle." in s_call[0][0] for s_call in mock_log_debug.call_args_list) or \
                             any("AIAlgo ran but provided no new configurations to apply." in s_call[0][0] for s_call in mock_log_debug.call_args_list) )
 
+        mock_save_price_tick.assert_called_once_with(session=mock_session, currency_pair=self.currency, price=self.current_value) # Added
+        mock_get_last_values.assert_called_once_with(session=mock_session, currency_pair=self.currency, count=algo_main.max_frequencies) # Added
 
         guppy_instance.update_config.assert_not_called()
         # Ensure no update_config was called on any algo
@@ -165,13 +183,16 @@ class TestAlgoMain(unittest.TestCase):
             if not isinstance(algo, AIAlgo):
                 algo.update_config.assert_not_called()
 
+    @patch('crypto_trading.database.core_operations.save_price_tick') # Added
     @patch('crypto_trading.algo.model.pricing.get_last_values')
-    def test_algo_main_process_ai_error_during_ai_process(self, mock_get_last_values):
+    def test_algo_main_process_ai_error_during_ai_process(self, mock_get_last_values, mock_save_price_tick): # Added mock_save_price_tick
         """Test AlgoMain.process when AIAlgo.process itself raises an error."""
         mock_get_last_values.return_value = []
+        mock_session = MagicMock(spec=Session) # Added
         config_data = {"AIAlgo": {"enabled": True, "model_path": "dummy/ai_model.pth"}, "GuppyMMA": {}, "Bollinger": {}, "MovingAverageCrossover": {}}
         self.write_config(config_data)
-        algo_main = AlgoMain(self.CONFIG_FILE_PATH)
+        config_obj = Config(algo_config_path=self.CONFIG_FILE_PATH)
+        algo_main = AlgoMain(config_obj)
 
         ai_algo_instance = next(algo for algo in algo_main.algo_ifs if isinstance(algo, AIAlgo))
         guppy_instance = next(algo for algo in algo_main.algo_ifs if isinstance(algo, GuppyMMA))
@@ -185,7 +206,7 @@ class TestAlgoMain(unittest.TestCase):
         ai_algo_instance.process = MagicMock(side_effect=Exception("AI Processing Failed!"))
 
         with patch.object(logging, 'error') as mock_log_error:
-            total_signal = algo_main.process(self.current_value, self.currency)
+            total_signal = algo_main.process(mock_session, self.current_value, self.currency) # Updated call
             # Check that the error from AIAlgo.process was logged
             self.assertTrue(any("Error processing AIAlgo" in s_call[0][0] for s_call in mock_log_error.call_args_list))
 
@@ -194,7 +215,31 @@ class TestAlgoMain(unittest.TestCase):
             if not isinstance(algo, AIAlgo):
                 algo.update_config.assert_not_called()
 
+        mock_save_price_tick.assert_called_once_with(session=mock_session, currency_pair=self.currency, price=self.current_value) # Added
+        mock_get_last_values.assert_called_once_with(session=mock_session, currency_pair=self.currency, count=algo_main.max_frequencies) # Added
         self.assertEqual(total_signal, 0) # Only non-AI signals contribute, which are mocked to 0
+
+    @patch('crypto_trading.algo.model.pricing.reset')
+    def test_algo_main_reset(self, mock_pricing_reset):
+        # Config data for AlgoMain instantiation
+        config_data = {"AIAlgo": {"enabled": False}}
+        self.write_config(config_data)
+        config_obj = Config(algo_config_path=self.CONFIG_FILE_PATH)
+        algo_main = AlgoMain(config_obj)
+
+        mock_session = MagicMock(spec=Session)
+        algo_main.reset(mock_session, self.currency)
+
+        mock_pricing_reset.assert_called_once_with(session=mock_session, currency_pair=self.currency)
+
+        # Example for checking sub-algo resets if they were implemented and called by AlgoMain.reset
+        # For GuppyMMA, if it had a reset method:
+        # guppy_instance = next((algo for algo in algo_main.algo_ifs if isinstance(algo, GuppyMMA)), None)
+        # if guppy_instance and hasattr(guppy_instance, 'reset'):
+        #     guppy_instance.reset = MagicMock() # If not already mocked or needs specific check
+        #     # Call algo_main.reset again or ensure it's part of the flow
+        #     guppy_instance.reset.assert_called_once_with(mock_session, self.currency)
+        # This part for sub-algos is illustrative; the primary check is mock_pricing_reset.
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
- Replaced SQLObject 'Pricing' model in `crypto_trading/algo/model/pricing.py` with the existing SQLAlchemy 'PriceTick' model.
- Updated functions in `crypto_trading/algo/model/pricing.py` (get_values, get_last_values, reset) to use SQLAlchemy sessions and queries.
- Modified `crypto_trading/algo/algoMain.py` to pass SQLAlchemy session objects to these updated functions.
- Replaced SQLObject-based price saving in `algoMain.py` with a call to the SQLAlchemy-based `save_price_tick` function from `core_operations.py`.
- Updated `tests/algo/algoContainer_tests.py` to reflect these changes, including mocking SQLAlchemy sessions, `save_price_tick`, and adjusting `AlgoMain` instantiation to use a `Config` object.
- Added a new test for `AlgoMain.reset`.