### PR TITLE
feat: Deploy PostgreSQL directly within Kubernetes cluster

### DIFF
--- a/code/config_management/schemas.py
+++ b/code/config_management/schemas.py
@@ -1,13 +1,29 @@
-from pydantic import BaseModel, FilePath, HttpUrl, DirectoryPath
+from pydantic import BaseModel, FilePath, HttpUrl, DirectoryPath, Field
+from pydantic_settings import BaseSettings, SettingsConfigDict # For Pydantic v2 style env var loading
 from typing import Optional, Dict, List
 
+# Try to import SettingsConfigDict for Pydantic v2, fallback for v1
+try:
+    from pydantic_settings import SettingsConfigDict
+    IS_PYDANTIC_V2 = True
+except ImportError:
+    from pydantic import BaseConfig
+    IS_PYDANTIC_V2 = False
+
 class DatabaseConfig(BaseModel):
-    type: str
-    host: str
-    port: int
-    username: str
-    password: str
-    name: str
+    type: str = Field(default="postgresql")
+    host: str = Field(default="localhost")
+    port: int = Field(default=5432)
+    username: str = Field(default="user")
+    password: str = Field(default="password")
+    name: str = Field(default="mydb")
+
+    if IS_PYDANTIC_V2:
+        model_config = SettingsConfigDict(env_prefix='APP_DB_', extra='ignore')
+    else:
+        class Config(BaseConfig):
+            env_prefix = 'APP_DB_'
+            extra = 'ignore' # Allow other env vars not matching the fields
 
 class ExchangeConfig(BaseModel):
     name: str
@@ -40,3 +56,9 @@ class AppConfig(BaseModel):
     base_config_path: Optional[DirectoryPath] = None
     # URL for the notification service
     notification_service_url: Optional[HttpUrl] = None
+
+    if IS_PYDANTIC_V2:
+        model_config = SettingsConfigDict(extra='ignore')
+    else:
+        class Config(BaseConfig):
+            extra = 'ignore'

--- a/infra/kubernetes/postgres-secret.yaml
+++ b/infra/kubernetes/postgres-secret.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: postgres-secret
+type: Opaque
+stringData:
+  POSTGRES_USER: "admin"
+  POSTGRES_PASSWORD: "password123" # Replace with a strong password, ideally from a secure generation process
+  POSTGRES_DB: "trading_db" # Optional: define a default database

--- a/infra/kubernetes/postgres-service.yaml
+++ b/infra/kubernetes/postgres-service.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: postgres-svc
+spec:
+  selector:
+    app: postgres
+  ports:
+    - protocol: TCP
+      port: 5432
+      targetPort: 5432
+  clusterIP: None # Headless service for StatefulSet

--- a/infra/kubernetes/postgres-statefulset.yaml
+++ b/infra/kubernetes/postgres-statefulset.yaml
@@ -1,0 +1,36 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: postgres
+spec:
+  serviceName: "postgres-svc"
+  replicas: 1 # Start with a single instance
+  selector:
+    matchLabels:
+      app: postgres
+  template:
+    metadata:
+      labels:
+        app: postgres
+    spec:
+      terminationGracePeriodSeconds: 10
+      containers:
+        - name: postgres
+          image: postgres:13 # Specify a version, e.g., postgres:13
+          ports:
+            - containerPort: 5432
+          envFrom:
+            - secretRef:
+                name: postgres-secret
+          volumeMounts:
+            - name: postgres-storage
+              mountPath: /var/lib/postgresql/data
+      # Define the volume claim template for persistent storage
+  volumeClaimTemplates:
+    - metadata:
+        name: postgres-storage
+      spec:
+        accessModes: ["ReadWriteOnce"] # Suitable for a single PostgreSQL instance
+        resources:
+          requests:
+            storage: 5Gi # Adjust storage size as needed

--- a/infra/kubernetes/trading_service_deployment.yaml
+++ b/infra/kubernetes/trading_service_deployment.yaml
@@ -19,21 +19,41 @@ spec:
         image: your-docker-registry/trading-service:latest # Placeholder - update with actual image
         ports:
         - containerPort: 8000
-        # env:
-        # - name: DATABASE_URL
-        #   value: "sqlite:////app/data/BINANCE_TRADES.db" # Example if DB path needs to be configurable
+        env:
+        - name: APP_DB_HOST
+          value: "postgres-svc"
+        - name: APP_DB_PORT
+          value: "5432"
+        - name: APP_DB_TYPE
+          value: "postgresql"
+        - name: APP_DB_NAME
+          valueFrom:
+            secretKeyRef:
+              name: postgres-secret
+              key: POSTGRES_DB
+        - name: APP_DB_USER
+          valueFrom:
+            secretKeyRef:
+              name: postgres-secret
+              key: POSTGRES_USER
+        - name: APP_DB_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: postgres-secret
+              key: POSTGRES_PASSWORD
+        # Example of other config vars if needed:
         # - name: ANOTHER_CONFIG_VAR
         #   valueFrom:
         #     configMapKeyRef:
-        #       name: trading-service-config
+        #       name: trading-service-config # Ensure this ConfigMap exists if used
         #       key: some_config_key
         # volumeMounts:
-        # - name: trading-db-storage
-        #   mountPath: /app/data # Example if using PV/PVC for SQLite
+        # - name: trading-db-storage # This might not be needed if DB is external
+        #   mountPath: /app/data
       # volumes:
-      # - name: trading-db-storage
+      # - name: trading-db-storage # This might not be needed if DB is external
       #   persistentVolumeClaim:
-      #     claimName: trading-db-pvc # Example PVC name
+      #     claimName: trading-db-pvc
 
 ---
 apiVersion: v1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 fastapi
 uvicorn[standard]
 pydantic
+pydantic-settings
 SQLAlchemy
 slack_sdk
 alembic


### PR DESCRIPTION
This commit introduces the necessary configurations to deploy PostgreSQL as a stateful service within the Kubernetes cluster.

Key changes include:
- Added Kubernetes manifests for PostgreSQL:
    - `infra/kubernetes/postgres-secret.yaml`: For database credentials.
    - `infra/kubernetes/postgres-service.yaml`: For the internal service endpoint.
    - `infra/kubernetes/postgres-statefulset.yaml`: For the PostgreSQL pods with persistent storage.
- Updated `code/config_management/schemas.py`:
    - Modified `DatabaseConfig` to allow overriding connection parameters via environment variables prefixed with `APP_DB_`.
    - Added `pydantic-settings` to `requirements.txt` for this functionality.
- Updated `infra/kubernetes/trading_service_deployment.yaml`:
    - Configured the `trading-service` to connect to the internal PostgreSQL service (`postgres-svc`).
    - Injects database host, port, name, user, and password as environment variables, with sensitive data sourced from `postgres-secret`.
- Updated `README.md`:
    - Added a new section "Kubernetes PostgreSQL Deployment" explaining the setup, configuration, and how to access the database for debugging.

This allows the application to use a PostgreSQL instance managed by Kubernetes, aligning with cloud-native deployment practices.